### PR TITLE
Fixed Deprecation Warning

### DIFF
--- a/demo/picture_demo.py
+++ b/demo/picture_demo.py
@@ -15,8 +15,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 from collections import OrderedDict
-from scipy.ndimage.morphology import generate_binary_structure
-from scipy.ndimage.filters import gaussian_filter, maximum_filter
+from scipy.ndimage import generate_binary_structure
+from scipy.ndimage import gaussian_filter, maximum_filter
 
 from lib.network.rtpose_vgg import get_model
 from lib.network import im_transform

--- a/demo/web_demo.py
+++ b/demo/web_demo.py
@@ -15,8 +15,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 from collections import OrderedDict
-from scipy.ndimage.morphology import generate_binary_structure
-from scipy.ndimage.filters import gaussian_filter, maximum_filter
+from scipy.ndimage import generate_binary_structure
+from scipy.ndimage import gaussian_filter, maximum_filter
 
 from lib.network.rtpose_vgg import get_model
 from lib.network import im_transform

--- a/video_demo.py
+++ b/video_demo.py
@@ -15,8 +15,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 from collections import OrderedDict
-from scipy.ndimage.morphology import generate_binary_structure
-from scipy.ndimage.filters import gaussian_filter, maximum_filter
+from scipy.ndimage import generate_binary_structure
+from scipy.ndimage import gaussian_filter, maximum_filter
 
 from lib.network.rtpose_vgg import get_model
 from lib.network import im_transform


### PR DESCRIPTION
**Fixed Deprecation Warning in demo files**
Running any of the demo files creates a deprecation warning.

The deprecated namespaces include:

- scipy.ndimage.morphology
- scipy.ndimage.filters

generate_binary_structure can now be imported from scipy.ndimage
gaussian_filter and maximum_filter can also be imported from scipy.ndimage